### PR TITLE
Support for lower case SGF properties

### DIFF
--- a/gomill/sgf_grammar.py
+++ b/gomill/sgf_grammar.py
@@ -32,7 +32,7 @@ _tokenise_re = re.compile(r"""
 (?:
     \[ (?P<V> [^\\\]]* (?: \\. [^\\\]]* )* ) \]   # PropValue
     |
-    (?P<I> [A-Z]{1,64} )                          # PropIdent
+    (?P<I> [A-Za-z]{1,64} )                          # PropIdent
     |
     (?P<D> [;()] )                                # delimiter
 )


### PR DESCRIPTION
SGF files from the IGS Pandanet Android app include a property called "CoPyright" (mix of lower and upper case letters).
Gomill fail to parse such SGF file, so here is a quick fix.